### PR TITLE
Fix DXF export to use text buffer

### DIFF
--- a/app.py
+++ b/app.py
@@ -106,8 +106,9 @@ def matrix_to_dxf(matrix: Tuple[Tuple[bool, ...], ...], module_size: float) -> i
                 close=True,
             )
 
-    buffer = io.BytesIO()
-    doc.write(stream=buffer)
+    text_buffer = io.StringIO()
+    doc.write(stream=text_buffer)
+    buffer = io.BytesIO(text_buffer.getvalue().encode("utf-8"))
     buffer.seek(0)
     return buffer
 


### PR DESCRIPTION
## Summary
- adjust DXF export to write via a text buffer and encode to bytes to avoid type errors when downloading files

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e72e75dca8832aa2ace6fb3add1bc6