### PR TITLE
Add configurable rounded corners for QR body and eyes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 Flask==3.0.2
 qrcode[pil]==7.4.2
-ezdxf==1.4.2

--- a/src/qr_dxf/matrix_utils.py
+++ b/src/qr_dxf/matrix_utils.py
@@ -1,0 +1,77 @@
+"""Utilities for working with QR code matrices."""
+
+from __future__ import annotations
+
+from typing import Sequence, Set, Tuple
+
+Coordinate = Tuple[int, int]
+
+
+def detect_quiet_zone(matrix: Sequence[Sequence[bool]]) -> int:
+    """Return the size of the quiet zone around ``matrix``.
+
+    The quiet zone is inferred by finding the minimum x/y coordinate that
+    contains an active module. This assumes the matrix includes the quiet zone
+    padding (which is the default for QR libraries).
+    """
+
+    size = len(matrix)
+    if size == 0:
+        return 0
+
+    min_x = size
+    min_y = size
+    for y, row in enumerate(matrix):
+        for x, value in enumerate(row):
+            if value:
+                if x < min_x:
+                    min_x = x
+                if y < min_y:
+                    min_y = y
+    if min_x == size or min_y == size:
+        return 0
+    return min(min_x, min_y)
+
+
+def finder_pattern_modules(
+    matrix: Sequence[Sequence[bool]],
+) -> Tuple[Set[Coordinate], Set[Coordinate]]:
+    """Return sets of coordinates for the finder pattern frame and eye modules.
+
+    The first set contains the outer frame modules, and the second contains the
+    inner "eye" modules. Coordinates are provided as ``(x, y)`` tuples using the
+    same orientation as the provided matrix.
+    """
+
+    size = len(matrix)
+    if size < 7:
+        return set(), set()
+
+    quiet_zone = detect_quiet_zone(matrix)
+    frame: Set[Coordinate] = set()
+    eyes: Set[Coordinate] = set()
+
+    origins = [
+        (quiet_zone, quiet_zone),
+        (size - quiet_zone - 7, quiet_zone),
+        (quiet_zone, size - quiet_zone - 7),
+    ]
+
+    for origin_x, origin_y in origins:
+        if origin_x < 0 or origin_y < 0:
+            continue
+        if origin_x + 7 > size or origin_y + 7 > size:
+            continue
+        for dy in range(7):
+            for dx in range(7):
+                x = origin_x + dx
+                y = origin_y + dy
+                if not matrix[y][x]:
+                    continue
+                if 2 <= dx <= 4 and 2 <= dy <= 4:
+                    eyes.add((x, y))
+                else:
+                    frame.add((x, y))
+
+    return frame, eyes
+

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -63,3 +63,26 @@ textarea {
   margin-bottom: 0.5rem;
   color: var(--muted-color);
 }
+
+.design-controls {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.design-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.design-control output {
+  align-self: flex-end;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.design-help {
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--muted-color);
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -6,6 +6,20 @@ const iconInput = document.getElementById("icon");
 const clearIconButton = document.getElementById("clear-icon");
 const iconSizeInput = document.getElementById("icon-size");
 const iconSizeValue = document.getElementById("icon-size-value");
+const designControls = [
+  {
+    input: document.getElementById("body-corner-radius"),
+    output: document.getElementById("body-corner-radius-value"),
+  },
+  {
+    input: document.getElementById("eye-frame-corner-radius"),
+    output: document.getElementById("eye-frame-corner-radius-value"),
+  },
+  {
+    input: document.getElementById("eye-ball-corner-radius"),
+    output: document.getElementById("eye-ball-corner-radius-value"),
+  },
+];
 
 let previewTimeout;
 let iconDataUrl = null;
@@ -49,6 +63,21 @@ function buildRequestPayload() {
   const iconSize = Number(formData.get("iconSize"));
   if (!Number.isNaN(iconSize)) {
     payload.iconSize = iconSize;
+  }
+
+  const bodyCornerRadius = Number(formData.get("bodyCornerRadius"));
+  if (!Number.isNaN(bodyCornerRadius)) {
+    payload.bodyCornerRadius = bodyCornerRadius;
+  }
+
+  const eyeFrameCornerRadius = Number(formData.get("eyeFrameCornerRadius"));
+  if (!Number.isNaN(eyeFrameCornerRadius)) {
+    payload.eyeFrameCornerRadius = eyeFrameCornerRadius;
+  }
+
+  const eyeBallCornerRadius = Number(formData.get("eyeBallCornerRadius"));
+  if (!Number.isNaN(eyeBallCornerRadius)) {
+    payload.eyeBallCornerRadius = eyeBallCornerRadius;
   }
 
   if (iconDataUrl) {
@@ -156,6 +185,18 @@ window.addEventListener("DOMContentLoaded", () => {
     iconSizeInput.addEventListener("input", updateIconSizeValue);
     updateIconSizeValue();
   }
+
+  designControls.forEach(({ input, output }) => {
+    if (!input || !output) {
+      return;
+    }
+    const updateValue = () => {
+      const value = Number(input.value);
+      output.textContent = Number.isFinite(value) ? `${value}%` : "";
+    };
+    input.addEventListener("input", updateValue);
+    updateValue();
+  });
 
   updatePreview();
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,6 +67,52 @@
             </div>
           </fieldset>
 
+          <fieldset>
+            <legend>デザイン</legend>
+            <div class="design-controls">
+              <label for="body-corner-radius" class="design-control">
+                Body の角丸
+                <input
+                  type="range"
+                  id="body-corner-radius"
+                  name="bodyCornerRadius"
+                  min="0"
+                  max="50"
+                  step="1"
+                  value="0"
+                />
+                <output id="body-corner-radius-value" for="body-corner-radius">0%</output>
+              </label>
+              <label for="eye-frame-corner-radius" class="design-control">
+                Eye Frame の角丸
+                <input
+                  type="range"
+                  id="eye-frame-corner-radius"
+                  name="eyeFrameCornerRadius"
+                  min="0"
+                  max="50"
+                  step="1"
+                  value="0"
+                />
+                <output id="eye-frame-corner-radius-value" for="eye-frame-corner-radius">0%</output>
+              </label>
+              <label for="eye-ball-corner-radius" class="design-control">
+                Eye Ball の角丸
+                <input
+                  type="range"
+                  id="eye-ball-corner-radius"
+                  name="eyeBallCornerRadius"
+                  min="0"
+                  max="50"
+                  step="1"
+                  value="0"
+                />
+                <output id="eye-ball-corner-radius-value" for="eye-ball-corner-radius">0%</output>
+              </label>
+            </div>
+            <small class="design-help">0%は角丸なし、50%は円形になります。</small>
+          </fieldset>
+
           <button type="submit" id="download-btn">DXFをダウンロード</button>
         </form>
       </section>


### PR DESCRIPTION
## Summary
- add form controls to configure rounded corners for the QR body, eye frame, and eye ball modules
- render previews and DXF exports with the chosen corner radii using shared matrix utilities
- drop the ezdxf dependency now that DXF output is generated directly

## Testing
- pytest
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68e735dec284832ab2a9494e18996bde